### PR TITLE
Extend Generate_token functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ To generate a token, you need to pass in `issuer`, `client_id`, `client_secret`,
 
 This generates and returns Okta Access Token.
 
-
 To Validate the Access Token, you need to pass in the `access_token`, `issuer`, `audience` and `client_ids` as parameters. You can pass in multiple Client IDs
 ```python
 	>>> from okta_jwt.jwt import validate_token

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ To generate a token, you need to pass in `issuer`, `client_id`, `client_secret`,
 
 This generates and returns Okta Access Token.
 
+PS: You can also configure additional parameters such as the `scope` and `grant_type`.
+
+\
 To Validate the Access Token, you need to pass in the `access_token`, `issuer`, `audience` and `client_ids` as parameters. You can pass in multiple Client IDs
 ```python
 	>>> from okta_jwt.jwt import validate_token

--- a/okta_jwt/jwt.py
+++ b/okta_jwt/jwt.py
@@ -10,7 +10,7 @@ JWKS_CACHE = {}
 
 
 # Generates Okta Access Token
-def generate_token(issuer, client_id, client_secret, username, password, scope='openid'):
+def generate_token(issuer, client_id, client_secret, username, password, scope='openid', grant_type='password'):
     """For generating a token, you need to pass in the Issuer,
     Client ID, Client Secret, Username and Password
     """
@@ -21,12 +21,12 @@ def generate_token(issuer, client_id, client_secret, username, password, scope='
         'Content-Type': 'application/x-www-form-urlencoded'
     }
 
-    # grant_type is gonna be constant
+    # Configurable payload parameters
     payload = {
         "username":   username,
         "password":   password,
         "scope":      scope,
-        "grant_type": "password"
+        "grant_type": grant_type
     }
 
     url = "{}/v1/token".format(issuer)


### PR DESCRIPTION
This pr extends the `generate_token()` function to give users the ability to pass in custom grant types other than `password`. It also updates the readme.

#### Fixes: #6 

#DFTB